### PR TITLE
Minor backup removal fixes

### DIFF
--- a/concrete/bootstrap/configure.php
+++ b/concrete/bootstrap/configure.php
@@ -75,7 +75,6 @@ define('NAMESPACE_SEGMENT_VENDOR', 'Concrete');
  * ----------------------------------------------------------------------------
  */
 define('DIRNAME_BLOCKS', 'blocks');
-define('DIRNAME_BACKUPS', 'backups');
 define('DIRNAME_PAGES', 'single_pages');
 define('DIRNAME_VIEWS', 'views');
 define('DIRNAME_PACKAGES', 'packages');

--- a/concrete/single_pages/dashboard/system/backup/backup.php
+++ b/concrete/single_pages/dashboard/system/backup/backup.php
@@ -1,8 +1,6 @@
 <?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
 
 <div class="alert alert-warning">
-    <p><?php echo t('Backing up your site is important. Typically your web host can help you make a complete backup of your environment
-    from your hosting control panel. Alternatively, there are additional backup solutions available in the concrete5.org marketplace.'); ?></p>
-    <a href="https://www.concrete5.org/marketplace/addons/-/view/?submit_search=1&search_keywords=backup">
-    <?php echo t('https://www.concrete5.org/marketplace/addons/-/view/?submit_search=1&search_keywords=backup'); ?></a>
+    <p><?php echo t('Backing up your site is important. Typically your web host can help you make a complete backup of your environment from your hosting control panel. Alternatively, there are additional backup solutions available in the concrete5.org marketplace.'); ?></p>
+    <a href="https://www.concrete5.org/marketplace/addons/-/view/?submit_search=1&search_keywords=backup"><?php echo t('https://www.concrete5.org/marketplace/addons/-/view/?submit_search=1&search_keywords=backup'); ?></a>
 </div>

--- a/concrete/single_pages/dashboard/system/backup/backup.php
+++ b/concrete/single_pages/dashboard/system/backup/backup.php
@@ -1,6 +1,8 @@
 <?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
 
 <div class="alert alert-warning">
-    <p><?php echo t('Backing up your site is important. Typically your web host can help you make a complete backup of your environment from your hosting control panel. Alternatively, there are additional backup solutions available in the concrete5.org marketplace.'); ?></p>
-    <a href="https://www.concrete5.org/marketplace/addons/-/view/?submit_search=1&search_keywords=backup"><?php echo t('https://www.concrete5.org/marketplace/addons/-/view/?submit_search=1&search_keywords=backup'); ?></a>
+    <p><?php echo t(
+        'Backing up your site is important. Typically your web host can help you make a complete backup of your environment from your hosting control panel. Alternatively, there are <a href="%s" target="_blank">additional backup solutions available in the concrete5.org marketplace</a>.',
+        h('https://www.concrete5.org/marketplace/addons/-/view/?submit_search=1&search_keywords=backup')
+    ); ?></p>
 </div>


### PR DESCRIPTION
- Remove the unused `DIRNAME_BACKUPS` constant
- Avoid unnecessary spaces in translatable strings
- Don't translate the marketplace URL
- Don't show the marketplace URL: it's unnecessary
